### PR TITLE
identical path matching before pattern matching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: microserver
 Type: Package
 Title: Microserver
-Version: 0.1.0
+Version: 0.1.1
 Description: Microserver is a package that builds on the httupv library
     and aims to provide a minimal set of tools to get a JSON-based
     REST API off the ground.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# Version 0.1.1
+
+* added identical matching before pattern matching in `determine_route`.

--- a/R/routes.r
+++ b/R/routes.r
@@ -16,6 +16,11 @@ determine_route <- function(routes, request_path) {
     (identical(names(routes), NULL) && length(routes) != 0) || '' %in% names(routes)
   routenames <- names(routes)[names(routes) != '']
   for (route in routenames) {
+    if (identical(route, request_path)) {
+      return(routes[[route]])
+    }
+  }
+  for (route in routenames) {
     if (grepl(paste0('^', route), request_path)) {
       return(routes[[route]])
     } else if (serve_static && file.exists(file.path("public", request_path))) {


### PR DESCRIPTION
I tried having two routes in a toy microserver called `\raw` and `\rawer`, and the microserver could never call the `\rawer` function.

I added a couple of lines of code to try identical matching before pattern matching when determining routes.